### PR TITLE
Adds tz cache and extracted zip for >10x faster resuming and processing

### DIFF
--- a/download_snapchat_memories_gui.py
+++ b/download_snapchat_memories_gui.py
@@ -1201,11 +1201,16 @@ class SnapchatDownloaderGUI:
         tools_str = " & ".join(tools)
         return f"✓ Conversion available via {tools_str}. Videos will be converted to H.264 for Windows compatibility."
     
-    def log(self, message):
-        """Add message to log area."""
+    def log(self, message, *, refresh=True):
+        """Add message to log area.
+
+        refresh=False skips the per-line UI flush — useful when dumping many
+        resume-skip lines so the worker isn't blocked on tk redraws.
+        """
         self.log_text.insert(tk.END, message + "\n")
         self.log_text.see(tk.END)
-        self.root.update_idletasks()
+        if refresh:
+            self.root.update_idletasks()
     
     def update_progress(self, current, total, is_resume_mode=False):
         """Update progress bar.
@@ -2235,6 +2240,11 @@ class SnapchatDownloaderGUI:
         if not zips:
             return root_dir
         dest = export_zip_utils.default_extract_root(root_dir)
+        if export_zip_utils.extract_is_up_to_date(dest, zips):
+            self.log(f"✓ Using existing extraction ({len(zips)} ZIPs unchanged)")
+            self.log(f"📂 {dest}")
+            self.log("")
+            return dest
         size = export_zip_utils.format_size(export_zip_utils.total_zip_size(zips))
         self.log(f"📦 Found {len(zips)} Snapchat export ZIP(s) ({size})")
         self.log(f"📂 Extracting to: {dest}")
@@ -2532,9 +2542,11 @@ class SnapchatDownloaderGUI:
                             expected.append(f"{date_str_preview}_{global_idx}_original{ext}")
 
                         if all((output_path / n).exists() for n in expected):
-                            self.log(f"[{global_idx}/{grand_total}] {fname}")
-                            self.log(f"  ↷ Skipped (already exists: {expected[0]})")
-                            self.log("")
+                            self.log(
+                                f"[{global_idx}/{grand_total}] ↷ Skipped "
+                                f"(already exists: {expected[0]})",
+                                refresh=(global_idx % 25 == 0 or global_idx == grand_total),
+                            )
                             total_skipped += 1
                             folder_success += 1
                             self.update_progress(global_idx, grand_total, is_resume_mode=False)

--- a/export_zip_utils.py
+++ b/export_zip_utils.py
@@ -13,8 +13,12 @@ Extraction restores each file's modification time from the ZIP entry
 uses the export's file times as a timestamp source. Already-extracted
 files with a matching size are skipped, so an interrupted extraction
 resumes where it left off.
+
+A stamp file records which ZIPs were fully extracted; on later runs the
+app skips the expensive per-member re-scan when those ZIPs are unchanged.
 """
 
+import json
 import logging
 import os
 import time
@@ -25,6 +29,7 @@ from datetime import datetime
 EXPORT_TOP_LEVEL_HINTS = ("memories", "chat_media", "json", "html", "index.html")
 
 EXTRACT_DIRNAME = "extracted"
+EXTRACT_STAMP_NAME = ".export_extract_stamp.json"
 
 MEMORIES_JSON_SUFFIX = "json/memories_history.json"
 
@@ -32,6 +37,58 @@ MEMORIES_JSON_SUFFIX = "json/memories_history.json"
 def default_extract_root(zip_dir):
     """Where a folder of export ZIPs gets extracted to."""
     return os.path.join(zip_dir, EXTRACT_DIRNAME)
+
+
+def _zip_fingerprint(zip_paths):
+    """Stable identity for a set of export ZIPs (name + size + mtime)."""
+    rows = []
+    for path in zip_paths:
+        try:
+            st = os.stat(path)
+            rows.append({
+                "name": os.path.basename(path),
+                "size": st.st_size,
+                "mtime_ns": getattr(st, "st_mtime_ns", int(st.st_mtime * 1_000_000_000)),
+            })
+        except OSError:
+            rows.append({"name": os.path.basename(path), "size": None, "mtime_ns": None})
+    rows.sort(key=lambda r: r["name"])
+    return rows
+
+
+def extract_stamp_path(dest_root):
+    return os.path.join(dest_root, EXTRACT_STAMP_NAME)
+
+
+def write_extract_stamp(dest_root, zip_paths):
+    """Record that dest_root is a complete extract of these ZIPs."""
+    payload = {
+        "version": 1,
+        "zips": _zip_fingerprint(zip_paths),
+        "completed_at": time.time(),
+    }
+    path = extract_stamp_path(dest_root)
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+    except OSError as exc:
+        logging.warning(f"Could not write extract stamp {path}: {exc}")
+
+
+def extract_is_up_to_date(dest_root, zip_paths):
+    """True when dest_root was fully extracted from these exact ZIPs already."""
+    if not zip_paths or not os.path.isdir(dest_root):
+        return False
+    path = extract_stamp_path(dest_root)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return False
+    stamped = payload.get("zips")
+    if not isinstance(stamped, list):
+        return False
+    return stamped == _zip_fingerprint(zip_paths)
 
 
 def looks_like_export_zip(zip_path):
@@ -166,6 +223,7 @@ def extract_export_zips(zip_paths, dest_root, log=None, progress=None, stop_chec
         stats["total"] += count
 
     done = 0
+    last_progress_at = 0.0
     for zip_path in zip_paths:
         if per_zip_counts.get(zip_path) is None:
             continue
@@ -210,10 +268,19 @@ def extract_export_zips(zip_paths, dest_root, log=None, progress=None, stop_chec
                             f"Failed to extract {info.filename} from "
                             f"{os.path.basename(zip_path)}: {exc}")
                         stats["errors"] += 1
-                    if progress:
+                    # Throttle UI progress — per-file redraws dominate on
+                    # large exports when almost everything is already present.
+                    if progress and (done == stats["total"]
+                                     or done % 200 == 0
+                                     or time.monotonic() - last_progress_at >= 0.25):
                         progress(done, stats["total"])
+                        last_progress_at = time.monotonic()
         except Exception as exc:
             if log:
                 log(f"⚠ Error reading {os.path.basename(zip_path)}: {exc}")
             stats["errors"] += 1
+
+    if not stats["aborted"] and stats["errors"] == 0 and zip_paths:
+        write_extract_stamp(dest_root, [p for p in zip_paths
+                                        if per_zip_counts.get(p) is not None])
     return stats

--- a/snap_utils.py
+++ b/snap_utils.py
@@ -15,6 +15,41 @@ except Exception as e:
     _TIMEZONE_IMPORT_ERROR = e
     logging.debug("Timezone support libraries not available: %s", e, exc_info=True)
 
+# TimezoneFinder loads a large geo dataset; constructing it per file made
+# resume/skip checks take ~1s each. Keep one shared instance (+ tz cache).
+_timezone_finder = None
+_pytz_cache = {}
+_system_tz = None
+
+
+def _get_timezone_finder():
+    global _timezone_finder
+    if _timezone_finder is None and HAS_TIMEZONE_SUPPORT:
+        _timezone_finder = TimezoneFinder()
+    return _timezone_finder
+
+
+def _get_pytz(tz_name):
+    tz = _pytz_cache.get(tz_name)
+    if tz is None:
+        tz = pytz.timezone(tz_name)
+        _pytz_cache[tz_name] = tz
+    return tz
+
+
+def _get_system_tz():
+    global _system_tz
+    if _system_tz is not None:
+        return _system_tz
+    local_tz = _get_pytz('UTC')
+    try:
+        import tzlocal
+        local_tz = _get_pytz(tzlocal.get_localzone_name())
+    except Exception:
+        pass
+    _system_tz = local_tz
+    return _system_tz
+
 
 def parse_date(date_str):
     """Parse date string from JSON format to timezone-aware datetime object.
@@ -61,10 +96,10 @@ def convert_to_local_timezone(utc_datetime, latitude, longitude, force_system_tz
     # Try GPS-based timezone lookup if coordinates are available
     if not force_system_tz and latitude is not None and longitude is not None:
         try:
-            tf = TimezoneFinder()
-            tz_name = tf.timezone_at(lat=latitude, lng=longitude)
+            tf = _get_timezone_finder()
+            tz_name = tf.timezone_at(lat=latitude, lng=longitude) if tf else None
             if tz_name:
-                local_tz = pytz.timezone(tz_name)
+                local_tz = _get_pytz(tz_name)
                 local_dt = utc_datetime.astimezone(local_tz)
                 offset_str = local_dt.strftime("%z")
                 offset_str = (offset_str[:-2] + ":" + offset_str[-2:]) if len(offset_str) >= 5 else "+00:00"
@@ -82,15 +117,7 @@ def convert_to_local_timezone(utc_datetime, latitude, longitude, force_system_tz
     
     # Fall back to system timezone
     try:
-        local_tz = pytz.timezone('UTC')
-        try:
-            import tzlocal
-            local_tz_str = tzlocal.get_localzone_name()
-            local_tz = pytz.timezone(local_tz_str)
-        except Exception:
-            # Fallback: try to detect from system
-            pass
-        
+        local_tz = _get_system_tz()
         local_dt = utc_datetime.astimezone(local_tz)
         offset_str = local_dt.strftime("%z")
         offset_str = (offset_str[:-2] + ":" + offset_str[-2:]) if len(offset_str) >= 5 else "+00:00"

--- a/tests/test_export_zip_utils.py
+++ b/tests/test_export_zip_utils.py
@@ -92,6 +92,20 @@ def test_extract_skips_existing_files(export_dir):
     assert stats["skipped"] == 7
 
 
+def test_extract_stamp_marks_complete_and_detects_changes(export_dir):
+    zips = export_zip_utils.find_export_zips(str(export_dir))
+    dest = export_zip_utils.default_extract_root(str(export_dir))
+    assert not export_zip_utils.extract_is_up_to_date(dest, zips)
+
+    export_zip_utils.extract_export_zips(zips, dest)
+    assert export_zip_utils.extract_is_up_to_date(dest, zips)
+    assert os.path.isfile(export_zip_utils.extract_stamp_path(dest))
+
+    # Touching a source ZIP invalidates the stamp so a re-run re-checks.
+    os.utime(zips[0], None)
+    assert not export_zip_utils.extract_is_up_to_date(dest, zips)
+
+
 def test_extract_reports_progress_and_stops(export_dir):
     zips = export_zip_utils.find_export_zips(str(export_dir))
     dest = export_zip_utils.default_extract_root(str(export_dir))


### PR DESCRIPTION
Awesome project!! :) I've got like 45gb of snapchat memories to export (22-zip files, childhood dog clips going back to 2016 lol) so it's been a good stress test opportunity. I'm going to help friends run through this too once I'm happy with my export. 

I noticed the resuming function taking awhile and figured out two fixes:

1. TimezoneFinder loads a large geo dataset; constructing it per file made resume/skip checks take ~1s each. Added cache to keep one shared instance so each check is near instantaneous. When resuming after catching up with the skip, the tz check on newly processed files is also faster due to the cache.

2. On resuming, added a skip when an extraction already looks complete. Added a completion stamp to skip the print of each file on re-scan when nothing changed.

(I'll look at your 10_sec_merge branch soon too just wanted to get this in separately)